### PR TITLE
Fix issue cannot select file to upload when add slide

### DIFF
--- a/ps_imageslider.php
+++ b/ps_imageslider.php
@@ -620,6 +620,7 @@ class Ps_ImageSlider extends Module implements WidgetInterface
     {
         if ('AdminModules' !== Tools::getValue('controller') ||
             Tools::getValue('configure') !== $this->name ||
+            Tools::getIsset('addSlide') ||
             Tools::getIsset('id_slide')) {
             return;
         }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Fix issue, button upload file selector not working in action add new slide. It created a js error, that disable action of upload file button.
| Type?         | bug fix
| BC breaks?    |  no
| Deprecations? |  no
| Fixed ticket? | Fixes PrestaShop/PrestaShop#31980.
| How to test?  | The issue is reproductible in PS version 1.7.6.4 to < 1.7.0. Goto ps_imageslider configuration, add new slide, click on upload button to select a file, no window is opened and thre is a js error: Uncaught Sortable: `el` must be an HTMLElement, not [object Undefined] in file Sortable.min.js:2:14322

